### PR TITLE
feat: make the arguments to webdriver.Chrome customizable

### DIFF
--- a/webbot/webbot.py
+++ b/webbot/webbot.py
@@ -37,10 +37,12 @@ class Browser:
         - List containing all the errors which might have occurred during performing an action like click ,type etc.
     """
 
-    def __init__(self, showWindow=True, proxy=None , downloadPath:str=None):
+    def __init__(self, showWindow=True, proxy=None , downloadPath:str=None, arguments=["--disable-dev-shm-usage","--no-sandbox"]):
         options = webdriver.ChromeOptions()
-        options.add_argument("--disable-dev-shm-usage")
-        options.add_argument("--no-sandbox")
+
+        for argument in arguments:
+            options.add_argument(argument)
+
         if downloadPath is not None and isinstance(downloadPath,str):
             absolutePath = os.path.abspath(downloadPath)
             if(not os.path.isdir(absolutePath)):
@@ -49,9 +51,11 @@ class Browser:
             options.add_experimental_option('prefs', {'download.default_directory' : absolutePath})
 
         if proxy is not None and isinstance(proxy, str):
-            options.add_argument("--proxy-server={}".format(proxy))
+            # Check if '--proxy-server' has not yet been set
+            if not any(arg.starts_with("--proxy-server") for arg in arguments):
+                options.add_argument("--proxy-server={}".format(proxy))
 
-        if not showWindow:
+        if not showWindow and '--headless' not in arguments:
             options.headless = True
             options.add_argument("--headless")
 


### PR DESCRIPTION
Currently, the arguments passed to the 'webdriver.Chrome' constructor are not
very flexible. This change makes them completely customizable keeping the
backward compatible behavior.

cc: @nateshmbhat 